### PR TITLE
Only use this if 0.0.6 doesn't work

### DIFF
--- a/tool-annotations/heatmap-scatterplot.json
+++ b/tool-annotations/heatmap-scatterplot.json
@@ -4,7 +4,7 @@
   "annotation": {
     "container_input_path": "/data/input.json",
     "extra_directories": ["/refinery-data"],
-    "image_name": "mccalluc/heatmap_scatter_dash:v0.0.5",
+    "image_name": "mccalluc/heatmap_scatter_dash:v0.0.7",
     "description": "Heatmaps and scatterplots from matrix data",
     "parameters": [
       {
@@ -18,6 +18,12 @@
         "description": "Should columns of heatmap be clustered?",
         "value_type": "BOOLEAN",
         "default_value": false
+      }
+      {
+        "name": "api_prefix",
+        "description": "API prefix",
+        "value_type": "STRING",
+        "default_value": ""
       }
     ],
     "file_relationship": {

--- a/tool-annotations/heatmap-scatterplot.json
+++ b/tool-annotations/heatmap-scatterplot.json
@@ -18,7 +18,7 @@
         "description": "Should columns of heatmap be clustered?",
         "value_type": "BOOLEAN",
         "default_value": false
-      }
+      },
       {
         "name": "api_prefix",
         "description": "API prefix",


### PR DESCRIPTION
We'll want Refinery code to fill in the parameter but *not* show it to the user.