### PR TITLE
bump to v0.1.2

### DIFF
--- a/tool-annotations/heatmap-scatterplot.json
+++ b/tool-annotations/heatmap-scatterplot.json
@@ -4,7 +4,7 @@
   "annotation": {
     "container_input_path": "/data/input.json",
     "extra_directories": ["/refinery-data"],
-    "image_name": "mccalluc/heatmap_scatter_dash:v0.1.1",
+    "image_name": "mccalluc/heatmap_scatter_dash:v0.1.2",
     "description": "Heatmaps and scatterplots from matrix data",
     "parameters": [],
     "file_relationship": {


### PR DESCRIPTION
- Fix zip file reading
- Unselected dots are grey rather than green
- scale and center
- metadata charting (but refinery has no way to use it)