### PR TITLE
Bump refinery-higlass-docker version

### DIFF
--- a/tool-annotations/higlass.json
+++ b/tool-annotations/higlass.json
@@ -4,7 +4,7 @@
   "annotation": {
     "container_input_path": "/data/input.json",
     "extra_directories": ["/refinery-data"],
-    "image_name": "scottx611x/refinery-higlass-docker:v0.2.2",
+    "image_name": "scottx611x/refinery-higlass-docker:v0.3.0",
     "description": "Explore genome interaction maps, including those arising from Hi-C data (see http://higlass.io for details).",
     "parameters": [],
     "file_relationship": {
@@ -13,7 +13,7 @@
       "name": "List of Input Files",
       "input_files": [
         {
-          "allowed_filetypes": [{"name": "COOLER"}],
+          "allowed_filetypes": [{"name": "COOLER"}, {"name": "BIGWIG"}],
           "name": "Input File",
           "description": "HiGlass-compatible Input File"
         }


### PR DESCRIPTION
- Bump version to `v0.3.0`
- Add bigwig as a supported filetype