### PR TITLE
Disable master build temporarily

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     - DJANGO_SETTINGS_MODULE=config.settings.prod
   matrix:
     - REFINERY_BRANCH=develop
-    - REFINERY_BRANCH=master
+    # - REFINERY_BRANCH=master
 
 install:
   - git clone https://github.com/refinery-platform/refinery-platform.git


### PR DESCRIPTION
- The fix in Refinery from https://github.com/refinery-platform/refinery-platform/pull/2722 hasn't made its way into `master` over there yet causing all builds here to fail.

Ref #41 

