### PR TITLE
bump heatmap version

### DIFF
--- a/tool-annotations/heatmap-scatterplot.json
+++ b/tool-annotations/heatmap-scatterplot.json
@@ -4,7 +4,7 @@
   "annotation": {
     "container_input_path": "/data/input.json",
     "extra_directories": ["/refinery-data"],
-    "image_name": "mccalluc/heatmap_scatter_dash:v0.1.10",
+    "image_name": "mccalluc/heatmap_scatter_dash:v0.1.11",
     "description": "Heatmaps and scatterplots from matrix data",
     "parameters": [],
     "file_relationship": {


### PR DESCRIPTION
This will handle the files from core with an extra non-numeric column: For now, we'll just ignore those values, but in the future we might concat them on to the key in the first column, or provide other special handling for row metadata.