### PR TITLE
Make Input selection UI more explicit

### DIFF
--- a/tool-annotations/heatmap-scatterplot.json
+++ b/tool-annotations/heatmap-scatterplot.json
@@ -17,7 +17,7 @@
          "input_files": [
            {
              "allowed_filetypes": [{"name": "CSV"}],
-             "name": "Count Files & Differential Expression Files",
+             "name": "Select the count file as #1, then hit '▸▸' below and select the differential gene expression file as #2",
              "description": "CSVs with genes as rows and conditions as columns & with differential expression information"
            }
         ]


### PR DESCRIPTION
- This isn't ideal, but Shannan and I think it really just needs to be spelled out explicitly if people are actually going to use it successfully.
- Maybe sniffing the filetypes would also help, but it may be a while till we have that, and even then, if people are expecting to make a distinction, having the computer do it might be more confusing?
- Using non-ascii characters for the arrows might save real estate, and make it more obvious where we're pointing? Would "»" be better?